### PR TITLE
Lat and Lon are stored as floats not strings.

### DIFF
--- a/places/bordeaux.json
+++ b/places/bordeaux.json
@@ -1,15 +1,15 @@
 { "city":
   {
     "name": "Bordeaux",
-    "lat" : "44.8382",
-    "lon" : "-0.5748",
+    "lat" : 44.8382,
+    "lon" : -0.5748,
     "defaultZoom": "14"
   },
   "places": [
     {
       "name": "Le Node",
-      "lat": "44.840458",
-      "lon": "-0.570447",
+      "lat": 44.840458,
+      "lon": -0.570447,
       "address":  "12 rue des Faussets",
       "type" : "coworking",
       "power": {"available": true, "comment": "at least 8"},
@@ -17,8 +17,8 @@
     },
     {
       "name": "Coolworking",
-      "lat": "44.843098",
-      "lon": "-0.572875",
+      "lat": 44.843098,
+      "lon": -0.572875,
       "address": "19 rue Esprit des Lois",
       "type" : "coworking",
       "power": {"available": true},

--- a/places/london.json
+++ b/places/london.json
@@ -1,15 +1,15 @@
 { "city":
   {
     "name": "london",
-    "lat" : "51.5073219",
-    "lon" : "-0.1276474",
+    "lat" : 51.5073219,
+    "lon" : -0.1276474,
     "defaultZoom": "13"
   },
   "places": [
    {
       "name": "Caffe Forum",
-      "lat": "51.4935507",
-      "lon": "-0.182199",
+      "lat": 51.4935507,
+      "lon": -0.182199,
       "address": "146 Gloucester Rd",
       "type" : "cafe",
       "power": {"available": true, "comment": "one socket"},

--- a/places/toulon.json
+++ b/places/toulon.json
@@ -1,15 +1,15 @@
 { "city":
   {
     "name": "toulon",
-    "lat" : "43.117",
-    "lon" : "5.9333",
+    "lat" : 43.117,
+    "lon" : 5.9333,
     "defaultZoom": "14"
   },
   "places": [
     {
       "name": "La Cantine by Tvt",
-      "lat": "43.120496",
-      "lon": "5.938807",
+      "lat": 43.120496,
+      "lon": 5.938807,
       "address":  "Maison des technologies, Place G.Pompidou",
       "type" : "coworking",
       "power": {"available": true, "comment": "at least 15"},

--- a/places/toulouse.json
+++ b/places/toulouse.json
@@ -1,23 +1,23 @@
 { "city":
   {
     "name": "toulouse",
-    "lat" : "43.607378",
-    "lon" : "1.4399286",
+    "lat" : 43.607378,
+    "lon" : 1.4399286,
     "defaultZoom": "14"
   },
   "places": [
     {
       "name": "La fabrique",
-      "lat": "43.607378",
-      "lon": "1.4399286",
+      "lat": 43.607378,
+      "lon": 1.4399286,
       "address":  "6 Place du Peyrou",
       "type" : "coffee/restaurant",
       "power": {"available": true, "comment": "at least 2"}
     },
     {
       "name": "Brasserie Père Léon",
-      "lat": "43.600474",
-      "lon": "1.443858999999975",
+      "lat": 43.600474,
+      "lon": 1.443858999999975,
       "address": "2 Place Esquirol" ,
       "type" : "brasserie",
       "power": {"available": false},
@@ -25,16 +25,16 @@
     },
     {
       "name": "The George and Dragon",
-      "lat": "43.607414",
-      "lon": "1.4396000000000413",
+      "lat": 43.607414,
+      "lon": 1.4396000000000413,
       "address": "1 Place du Peyrou",
       "type" : "pub",
       "power": {"available": true}
     },
     {
       "name": "L'impro",
-      "lat": "43.602984",
-      "lon": "1.4416109999999662",
+      "lat": 43.602984,
+      "lon": 1.4416109999999662,
       "address": "7 Carriera Leon Gambetta" ,
       "type" : "coffee",
       "power": {"available": false},
@@ -42,8 +42,8 @@
     },
     {
       "name": "Un bout du monde",
-      "lat": "43.606091", 
-      "lon": "1.441757",
+      "lat": 43.606091, 
+      "lon": 1.441757,
       "address": "18, rue des penitents gris" ,
       "type" : "coffee",
       "power": {"available": true},
@@ -51,8 +51,8 @@
     },
     {
       "name": "Les coudes sur la table",
-      "lat": "43.607103", 
-      "lon": "1.439847",
+      "lat": 43.607103, 
+      "lon": 1.439847,
       "address": "39, rue des lois" ,
       "type" : "coffee",
       "power": {"available": true},


### PR DESCRIPTION
So we don't rely on javascript automagic inference/conversion. Probably safer :)

fix #18
