### PR TITLE
allow to run javascript test from console line with mocha-phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 before_script:
   - wget http://stedolan.github.io/jq/download/linux64/jq && chmod u+x jq
+  - npm install -g mocha
+  - npm install mocha-phantomjs
 
 script:
   - ./jq '.' locations/*.json
+  - ./node_modules/mocha-phantomjs/bin/mocha-phantomjs ./test/index.html

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,14 @@ Open issue, fork, commit and pull request. But you already know that :)
 
 Please, don't improve code/add new feature and add new places/locations in the same pull request.
 
+### Unit testing
+We now can run unit tests against devfriendlyplaces code. You can start them by two ways:
+* from your favorite browser, open the file test/index.html
+* from the console
+  * you first need to have a valid npm installation. Then
+    * `npm install -g mocha`
+    * `npm install mocha-phantomjs chai`
+  * then `./node_modules/mocha-phantomjs/bin/mocha-phantomjs ./test/index.html`
 
 [albi]: http://albi.devfriendlyplaces.net
 [angers]: http://angers.devfriendlyplaces.net

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
         <script src="../js/map.js"></script>
         <script src="../js/locations.js"></script>
         <script src="./test.js"></script>
-        <script>mocha.run();</script>
+        <script>(window.mochaPhantomJS || window.mocha).run();</script>
     </body>
 </html>
 


### PR DESCRIPTION
To run unit test from console, you'll need to
 * npm install -g mocha
 * npm install chai mocha-phantomjs

then  ./node_modules/mocha-phantomjs/bin/mocha-phantomjs ./test/index.html